### PR TITLE
Fix age default value

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/BorrowersStatus/Borrower.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/BorrowersStatus/Borrower.pm
@@ -109,7 +109,7 @@ sub status {
             cardnumber     => $borrower->cardnumber || '',
             surname        => $borrower->surname || '',
             firstname      => $borrower->firstname || '',
-            age            =>  $borrower->get_age || '',
+            age            =>  $borrower->get_age || 0,
             email            =>  $borrower->email || '',
             homebranch     => $borrower->branchcode || '',
             fines          => $fines_amount+0,


### PR DESCRIPTION
Age is defined as an integer. Thus default cannot be ''. This commit sets default age as 0.