### PR TITLE
Remove unnecessary dependency Data::Printer

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/BorrowersStatus/Borrower.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/BorrowersStatus/Borrower.pm
@@ -31,7 +31,6 @@ use Koha::Plugin::Fi::KohaSuomi::BorrowersStatus::Exceptions::Exception;
 
 use Scalar::Util qw( blessed );
 use Try::Tiny;
-use Data::Printer;
 use File::Basename;
 use POSIX qw(strftime);
 


### PR DESCRIPTION
Use of [Data::Printer](https://metacpan.org/pod/Data::Printer) is forbidden by Koha (as defined by [qa-test-tools](https://git.koha-community.org/Koha-community/qa-test-tools/commit/1569a8e095ebcaa0f288aa740369a83c250e5c8c?style=unified&whitespace=ignore-change)). For historical reasons it seems to be imported in this plugin. As it is no longer shipped with Koha, it should be removed because otherwise the plugin will crash with a missing dependency.

I couldn't find any use of Data::Printer's p() or np() so it seems Data::Printer is imported for no reason.